### PR TITLE
Build failure on nixOS. ModuleNotFoundError: No module named 'viu'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,6 @@
           # Needs to be adapted for the nix derivation build
           doCheck = false;
 
-          pythonImportsCheck = [ "viu" ];
-
           meta = {
             description = "Your browser anime experience from the terminal";
             homepage = "https://github.com/Benexl/Viu";


### PR DESCRIPTION
The current Nix flake fails to build with the following error:
`ModuleNotFoundError: No module named 'viu'`

Full error log:
```
error: builder for '/nix/store/0nhx5bq91g64pqmp535w7pkn2bj264fx-viu-3.1.0.drv' failed with exit code 1;
       last 25 log lines:
       > checking for references to /build/ in /nix/store/v69nf7vgc8zvdd6pvlpi9aa4ahwhvws1-viu-3.1.0...
       > patching script interpreter paths in /nix/store/v69nf7vgc8zvdd6pvlpi9aa4ahwhvws1-viu-3.1.0
       > stripping (with command strip and flags -S -p) in  /nix/store/v69nf7vgc8zvdd6pvlpi9aa4ahwhvws1-viu-3.1.0/lib /nix/store/v69nf7vgc8zvdd6pvlpi9aa4ahwhvws1-viu-3.1.0/bin
       > shrinking RPATHs of ELF executables and libraries in /nix/store/5xxr6lhsh4f71n121b3npdsdy13nwdh2-viu-3.1.0-dist
       > checking for references to /build/ in /nix/store/5xxr6lhsh4f71n121b3npdsdy13nwdh2-viu-3.1.0-dist...
       > patching script interpreter paths in /nix/store/5xxr6lhsh4f71n121b3npdsdy13nwdh2-viu-3.1.0-dist
       > Rewriting #!/nix/store/h097imm3w6dpx10qynrd2sz9fks2wbq8-python3-3.12.11/bin/python3.12 to #!/nix/store/h097imm3w6dpx10qynrd2sz9fks2wbq8-python3-3.12.11
       > wrapping `/nix/store/v69nf7vgc8zvdd6pvlpi9aa4ahwhvws1-viu-3.1.0/bin/viu'...
       > Executing pythonRemoveTestsDir
       > Finished executing pythonRemoveTestsDir
       > Running phase: pythonCatchConflictsPhase
       > Running phase: pythonRemoveBinBytecodePhase
       > Running phase: pythonImportsCheckPhase
       > Executing pythonImportsCheckPhase
       > Check whether the following modules can be imported: viu
       > Traceback (most recent call last):
       >   File "<string>", line 1, in <module>
       >   File "<string>", line 1, in <lambda>
       >   File "/nix/store/h097imm3w6dpx10qynrd2sz9fks2wbq8-python3-3.12.11/lib/python3.12/importlib/__init__.py", line 90, in import_module
       >     return _bootstrap._gcd_import(name[level:], package, level)
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
       > ModuleNotFoundError: No module named 'viu'
       For full logs, run:
         nix log /nix/store/0nhx5bq91g64pqmp535w7pkn2bj264fx-viu-3.1.0.drv
```

I've removed the line `pythonImportsCheck = [ "viu" ];` in flake.nix and now it's successfully building again.